### PR TITLE
[修复]：剔除 librtmp-jni.so 以支持 16KB 页面对齐

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -140,6 +140,7 @@ android {
     }
     packaging {
         resources.excludes.add('META-INF/*')
+        jniLibs.excludes.add('lib/*/librtmp-jni.so')
     }
 
     sourceSets {


### PR DESCRIPTION
## 问题
16KB 页面设备（Android 15+）运行报 "not 16 KB aligned"，Google Play Console 同样警告。

## 原因
librtmp-jni.so 来自 io.antmedia:rtmp-client:3.2.0（经 gsyvideoplayer-exo2 → media3-datasource-rtmp 传递引入），ELF segment 仅 4KB 对齐。

上游修复 PR（ant-media/LibRtmp-Client-for-Android#110）已合并但未发版，Maven 仍只有 3.2.0（2021年）。

## 方案
packaging 中排除 librtmp-jni.so，GSYVideoPlayer 作者 CarGuo 官方建议（CarGuo/GSYVideoPlayer#4178）。

legado 代码无 RTMP 引用，不影响功能。

## 对比
| 修改前 | 修改后 |
|:---:|:---:|
| <img width="1080" height="2400" alt="Screenshot_20260712_201547" src="https://github.com/user-attachments/assets/f3fd303d-00fc-41d8-9246-2512da178e18" /> | <img width="1080" height="2400" alt="Screenshot_20260712_201856" src="https://github.com/user-attachments/assets/bddd047c-5fa3-4192-8f52-1eb8b64d2157" /> |

## 测试环境

| 项目 | 值 |
|---|---|
| 系统镜像 | google_apis_ps16k / android-37.1 |
| Android 版本 | 17 (API 37) |
| Build | CP31.260618.005 |
| ABI | x86_64 |
| 页面大小 | 16 KB |
| 屏幕 | 1080×2400 @ 420dpi |
| CPU/RAM | x86_64 4核 / 2048MB |