### PR TITLE
[修复]：EPUB删除Ruby标签功能

### DIFF
--- a/app/src/main/java/io/legado/app/data/entities/Book.kt
+++ b/app/src/main/java/io/legado/app/data/entities/Book.kt
@@ -340,7 +340,7 @@ data class Book(
     }
 
     fun addDelTag(tag: Long) {
-        config.delTag = config.delTag and tag
+        config.delTag = config.delTag or tag
     }
 
     fun removeDelTag(tag: Long) {

--- a/app/src/main/java/io/legado/app/model/localBook/EpubFile.kt
+++ b/app/src/main/java/io/legado/app/model/localBook/EpubFile.kt
@@ -22,6 +22,7 @@ import me.ag2s.epublib.epub.EpubReader
 import me.ag2s.epublib.util.zip.AndroidZipFile
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
+import org.jsoup.nodes.TextNode
 import org.jsoup.parser.Parser
 import org.jsoup.select.Elements
 import java.io.File
@@ -175,7 +176,28 @@ class EpubFile(var book: Book) {
         }
         val tag = Book.rubyTag
         if (book.getDelTag(tag)) {
-            elements.select("rp, rt").remove()
+              // merge ruby node with adjacent textNodes to avoid unwanted whitespace
+            element.select("ruby").forEach { ruby ->
+                ruby.select("rp, rt").remove()
+                val textNode = TextNode(ruby.text())
+                ruby.replaceWith(textNode)
+                val prev = textNode.previousSibling()
+                val next = textNode.nextSibling()
+                when {
+                    prev is TextNode -> {
+                        prev.text(prev.text() + textNode.text())
+                        textNode.remove()
+                        if (next is TextNode) {
+                            prev.text(prev.text() + next.text())
+                            next.remove()
+                        }
+                    }
+                    next is TextNode -> {
+                        textNode.text(textNode.text() + next.text())
+                        next.remove()
+                    }
+                }
+            }
         }
         val html = elements.outerHtml()
         return HtmlFormatter.formatKeepImg(html)


### PR DESCRIPTION
* 修复开关逻辑，让删除ruby和h标签的功能生效
* 在打开“删除Ruby标签”时，合并前后的TextNode以去除多余的空格

EPUB渲染的classic方式中这些功能依旧无法正常工作，此修复仅针对new方式

修复 #449
